### PR TITLE
Add support for floats and multiple estimation labels on a single card

### DIFF
--- a/app/injected.js
+++ b/app/injected.js
@@ -76,10 +76,12 @@ async function main() {
                 continue;
             }
 
-            const estimation = cardLabels.map((label) => {
+            const estimation = cardLabels.reduce((accumulator, label) => {
                 const found = label.match(ESTIMATION_REGX);
-                return found?.groups?.estimation;
-            }).find((estimation) => estimation != null);
+                const number = Number(found?.groups?.estimation);
+                if (isNaN(number)) return accumulator;
+                return accumulator + number;
+            }, 0);
 
             if (!estimation) {
                 callBackNotEstimatedCard(card);
@@ -88,7 +90,7 @@ async function main() {
 
             log(estimation, card, cardLabels);
 
-            estimationSum = estimationSum + parseInt(estimation);
+            estimationSum = estimationSum + estimation;
         }
 
         const estimationBadgeElement = document.createElement('span');


### PR DESCRIPTION
This PR adds support for estimation labels to include floating point numbers (e.g. `0.5`) AND sums up all labels that match the `ESTIMATION_REGX` for each card.